### PR TITLE
Porting archs to common base.js

### DIFF
--- a/libdec/arch/base.js
+++ b/libdec/arch/base.js
@@ -1,0 +1,224 @@
+/* 
+ * Copyright (C) 2017 deroad
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+module.exports = (function() {
+
+    var _call_common = {
+        'textdomain': ['#include <libintl.h>'],
+        'setlocale': ['#include <locale.h>'],
+        'wcscmp': ['#include <wchar.h>'],
+        'strcmp': ['#include <string.h>'],
+        'strncmp': ['#include <string.h>'],
+        'memcpy': ['#include <string.h>'],
+        'strcpy': ['#include <string.h>'],
+        'puts': ['#include <stdio.h>'],
+        'printf': ['#include <stdio.h>'],
+        'scanf': ['#include <stdio.h>'],
+        'isoc99_scanf': ['#include <stdio.h>']
+    };
+
+    var _dependency = function(macros, code) {
+        this.macros = macros || [];
+        this.code = code || '';
+    }
+
+    var _pseudocode = function(context, dependencies) {
+        this.ctx = context;
+        this.deps = dependencies || new _dependency();
+        this.toString = function() {
+            return this.ctx.toString();
+        };
+    };
+
+    var _cmps = {
+        CMP_INF: ['1', '0'],
+        CMP_EQ: [' == ', ' != '],
+        CMP_NE: [' != ', ' == '],
+        CMP_LT: [' < ', ' >= '],
+        CMP_LE: [' <= ', ' > '],
+        CMP_GT: [' > ', ' <= '],
+        CMP_GE: [' >= ', ' < ']
+    };
+
+    var _common_math = function(op, destination, source_a, source_b) {
+        this.op = op;
+        this.dst = destination;
+        this.srcA = source_a;
+        this.srcB = source_b;
+        this.toString = function() {
+            if (this.srcA == this.dst) {
+                return this.dst + ' ' + this.op + '= ' + this.srcB;
+            }
+            return this.dst + ' = ' + this.srcB + ' ' + this.op + ' ' + this.srcB;
+        };
+    };
+
+    var _common_memory = function(bits, is_signed, pointer, register, is_write) {
+        this.reg = register;
+        this.pointer = pointer;
+        this.bits = bits ? ('(' + (is_signed ? '' : 'u') + 'int' + bits + '_t*)') : '';
+        if (is_write) {
+            this.toString = function() {
+                return '*(' + this.bits + ' ' + this.pointer + ') = ' + this.reg;
+            };
+        } else {
+            this.toString = function() {
+                return this.reg + ' = *(' + this.bits + ' ' + this.pointer + ')';
+            };
+        }
+    };
+
+    var _common_conditional = function(cmp, a, b, inverse) {
+        this.a = a;
+        this.b = b;
+        this.cmp = cmp;
+        this.inverse = inverse ? 1 : 0;
+        this.setInverse = function(b) {
+            this.inverse = b ? 1 : 0;
+        }
+        this.toString = function() {
+            return this.a + _cmps[this.cmp][this.inverse] + this.b;
+        };
+    };
+
+    var _common_rotate = function(destination, source_a, source_b, bits, is_left) {
+        this.call = 'rotate_' + (is_left ? 'left' : 'right') + bits;
+        this.dst = destination;
+        this.srcA = source_a;
+        this.srcB = source_b;
+        this.toString = function() {
+            return this.dst + ' = ' + this.call + ' (' + this.srcA + ', ' + this.srcB + ')';
+        };
+    };
+
+    var _common_assign = function(destination, source) {
+        this.dst = destination;
+        this.src = source;
+        this.toString = function() {
+            return this.dst + ' = ' + this.src;
+        };
+    }
+
+    return {
+        assign: function(destination, source) {
+            return new _pseudocode(new _common_assign(destination, source));
+        },
+        return: function(register) {
+            if (register) {
+                return new _pseudocode('return ' + register);
+            }
+            return new _pseudocode('return');
+        },
+        jump: function(address) {
+            return new _pseudocode('goto address_' + address.toString(16));
+        },
+        nop: function(destination, source_a, source_b) {
+            return null;
+        },
+        and: function(destination, source_a, source_b) {
+            return new _pseudocode(new _common_math('&', destination, source_a, source_b));
+        },
+        or: function(destination, source_a, source_b) {
+            return new _pseudocode(new _common_math('|', destination, source_a, source_b));
+        },
+        xor: function(destination, source_a, source_b) {
+            return new _pseudocode(new _common_math('^', destination, source_a, source_b));
+        },
+        add: function(destination, source_a, source_b) {
+            return new _pseudocode(new _common_math('+', destination, source_a, source_b));
+        },
+        subtract: function(destination, source_a, source_b) {
+            return new _pseudocode(new _common_math('-', destination, source_a, source_b));
+        },
+        multiply: function(destination, source_a, source_b) {
+            return new _pseudocode(new _common_math('*', destination, source_a, source_b));
+        },
+        divide: function(destination, source_a, source_b) {
+            return new _pseudocode(new _common_math('/', destination, source_a, source_b));
+        },
+        module: function(destination, source_a, source_b) {
+            return new _pseudocode(new _common_math('%', destination, source_a, source_b));
+        },
+        not: function(destination, source_a) {
+            return new _pseudocode(new _common_math('', destination, '!', source_a));
+        },
+        negate: function(destination, source_a) {
+            return new _pseudocode(new _common_math('', destination, '-', source_a));
+        },
+        shift_left: function(destination, source_a, source_b) {
+            return new _pseudocode(new _common_math('<<', destination, source_a, source_b));
+        },
+        shift_right: function(destination, source_a, source_b) {
+            return new _pseudocode(new _common_math('>>', destination, source_a, source_b));
+        },
+        rotate_left: function(destination, source_a, source_b, bits) {
+            return new _pseudocode(new _common_rotate(destination, source_a, source_b, bits, true),
+                new _dependency(['#include <stdint.h>', '#include <limits.h>'], 'uint###_t rotate_left### (uint###_t value, unsigned int count) {\n\tconst unsigned int mask = (CHAR_BIT * sizeof(value)) - 1;\n\tcount &= mask;\n\treturn (value << count) | (value >> (-count & mask));\n}\n'.replace(/###/g, bits.toString()))
+            );
+        },
+        rotate_right: function(destination, source_a, source_b, bits) {
+            return new _pseudocode(new _common_rotate(destination, source_a, source_b, bits, false),
+                new _dependency(['#include <stdint.h>', '#include <limits.h>'], 'uint###_t rotate_right### (uint###_t value, unsigned int count) {\n\tconst unsigned int mask = (CHAR_BIT * sizeof(value)) - 1;\n\tcount &= mask;\n\treturn (value >> count) | (value << (-count & mask));\n}'.replace(/###/g, bits.toString()))
+            );
+        },
+        read_memory: function(pointer, register, bits, is_signed) {
+            return new _pseudocode(new _common_memory(bits, is_signed, pointer, register, false));
+        },
+        write_memory: function(pointer, register, bits, is_signed) {
+            return new _pseudocode(new _common_memory(bits, is_signed, pointer, register, true));
+        },
+        call: function(address, args) {
+            var macros = _call_common[address];
+            if (macros) {
+                macros = new _dependency(macros);
+            }
+            return new _pseudocode(address + ' (' + args.join(', ') + ')', macros);
+        },
+        call: function(address, args, is_pointer) {
+            args = args || [];
+            var macros = _call_common[address];
+            if (macros) {
+                macros = new _dependency(macros);
+            }
+            if (is_pointer) {
+                address = '(*(void(*)(' + (args.lenght > 0 ? '...' : '') + ')) ' + address + ')'
+            }
+            return new _pseudocode(address + ' (' + args.join(', ') + ')', macros);
+        },
+        branch_equal: function(a, b) {
+            return new _pseudocode(new _common_conditional('CMP_EQ', a, b, false));
+        },
+        branch_not_equal: function(a, b) {
+            return new _pseudocode(new _common_conditional('CMP_NE', a, b, false));
+        },
+        branch_less: function(a, b) {
+            return new _pseudocode(new _common_conditional('CMP_LT', a, b, false));
+        },
+        branch_less_equal: function(a, b) {
+            return new _pseudocode(new _common_conditional('CMP_LE', a, b, false));
+        },
+        branch_greater: function(a, b) {
+            return new _pseudocode(new _common_conditional('CMP_GT', a, b, false));
+        },
+        branch_greater_equal: function(a, b) {
+            return new _pseudocode(new _common_conditional('CMP_GE', a, b, false));
+        },
+        unknown: function(data) {
+            return new _pseudocode('_asm(\"' + data + '\")');
+        }
+    };
+})();

--- a/libdec/arch/ppc.js
+++ b/libdec/arch/ppc.js
@@ -344,13 +344,13 @@ module.exports = (function() {
         var a = swap ? 3 : 2;
         var b = swap ? 2 : 3;
         if (e[1] == e[a] && !bits) {
-            return e[1] + " " + op + "= " + e[b] + ";";
+            return e[1] + " " + op + "= " + e[b];
         }
-        return e[1] + " = " + (bits ? '(uint' + bits + '_t) ' : '') + e[a] + " " + op + " " + e[b] + ";";
+        return e[1] + " = " + (bits ? '(uint' + bits + '_t) ' : '') + e[a] + " " + op + " " + e[b];
     };
 
     var op_rotate = function(e, bits, left) {
-        return e[1] + ' = ' + (left ? 'rol' : 'ror') + bits + ' (' + e[2] + ', ' + e[3] + ');';
+        return e[1] + ' = ' + (left ? 'rol' : 'ror') + bits + ' (' + e[2] + ', ' + e[3] + ')';
     };
 
     var mask32 = function(mb, me) {
@@ -396,32 +396,32 @@ module.exports = (function() {
         var s = unsigned ? "u" : "";
         var arg = e[2].replace(/\)/, '').split('(');
         if (arg[1] == '0') {
-            return e[1] + " = *((" + s + "int" + bits + "_t*) " + arg[0] + ");";
+            return e[1] + " = *((" + s + "int" + bits + "_t*) " + arg[0] + ")";
         } else if (arg[0] == '0') {
-            return e[1] + " = *((" + s + "int" + bits + "_t*) " + arg[1] + ");";
+            return e[1] + " = *((" + s + "int" + bits + "_t*) " + arg[1] + ")";
         }
         arg[0] = parseInt(arg[0]) / (bits / 8);
         if (arg[0] < 0)
             arg[0] = " - " + Math.abs(arg[0]);
         else
             arg[0] = " + " + arg[0];
-        return e[1] + " = *(((" + s + "int" + bits + "_t*) " + arg[1] + ")" + arg[0] + ");";
+        return e[1] + " = *(((" + s + "int" + bits + "_t*) " + arg[1] + ")" + arg[0] + ")";
     };
 
     var store_bits = function(e, bits, unsigned) {
         var s = unsigned ? "u" : "";
         var arg = e[2].replace(/\)/, '').split('(');
         if (arg[1] == '0') {
-            return "*((" + s + "int" + bits + "_t*) " + arg[0] + ") = " + e[1] + ";";
+            return "*((" + s + "int" + bits + "_t*) " + arg[0] + ") = " + e[1];
         } else if (arg[0] == '0') {
-            return "*((" + s + "int" + bits + "_t*) " + arg[1] + ") = " + e[1] + ";";
+            return "*((" + s + "int" + bits + "_t*) " + arg[1] + ") = " + e[1];
         }
         arg[0] = parseInt(arg[0]) / (bits / 8);
         if (arg[0] < 0)
             arg[0] = " - " + Math.abs(arg[0]);
         else
             arg[0] = " + " + arg[0];
-        return "*(((" + s + "int" + bits + "_t*) " + arg[1] + ")" + arg[0] + ") = " + e[1] + ";";
+        return "*(((" + s + "int" + bits + "_t*) " + arg[1] + ")" + arg[0] + ") = " + e[1];
     };
 
     var load_idx_bits = function(instr, bits, unsigned) {
@@ -430,9 +430,9 @@ module.exports = (function() {
         var s = unsigned ? "u" : "";
         var sbits = bits > 8 ? "((" + s + "int" + bits + "_t*) (" : "";
         if (e[2] == '0') {
-            return e[1] + " = *(" + sbits + e[3] + ");";
+            return e[1] + " = *(" + sbits + e[3] + ")";
         }
-        return e[1] + " = *(" + sbits + "(uint8_t*)" + e[2] + " + " + e[3] + (bits > 8 ? ")" : "") + ");";
+        return e[1] + " = *(" + sbits + "(uint8_t*)" + e[2] + " + " + e[3] + (bits > 8 ? ")" : "") + ")";
     };
 
     var store_idx_bits = function(instr, bits, unsigned) {
@@ -440,9 +440,9 @@ module.exports = (function() {
         instr.comments.push('with lock');
         var s = unsigned ? "u" : "";
         if (e[2] == '0') {
-            return "*((" + s + "int" + bits + "_t*) " + e[3] + ") = " + e[1] + ";";
+            return "*((" + s + "int" + bits + "_t*) " + e[3] + ") = " + e[1];
         }
-        return "*((" + s + "int" + bits + "_t*) " + "((uint8_t*)" + e[2] + " + " + e[3] + ")) = " + e[1] + ";";
+        return "*((" + s + "int" + bits + "_t*) " + "((uint8_t*)" + e[2] + " + " + e[3] + ")) = " + e[1];
     };
 
     var _compare = function(instr, context, bits) {
@@ -538,20 +538,20 @@ module.exports = (function() {
                 if (fcn_name.indexOf('0x') == 0) {
                     fcn_name = fcn_name.replace(/0x/, 'fcn_');
                 }
-                return fcn_name + " ();";
+                return fcn_name + " ()";
             },
             bdnz: function(instr, context) {
                 instr.conditional('(--ctr)', '0', 'NE');
                 return null;
             },
             blrl: function(instr, context) {
-                return '(*(void(*)()) lr) ();';
+                return '(*(void(*)()) lr) ()';
             },
             bctrl: function(instr, context) {
-                return '(*(void(*)()) ctr) ();';
+                return '(*(void(*)()) ctr) ()';
             },
             mtlr: function(instr) {
-                return '_mtlr (' + instr.parsed[1] + ');';
+                return '_mtlr (' + instr.parsed[1] + ')';
             },
             blr: function(instr, context, instructions) {
                 var start = instructions.indexOf(instr);
@@ -561,11 +561,11 @@ module.exports = (function() {
                             continue;
                         }
                         if (instructions[i].parsed[1] == 'r3') {
-                            return "return r3;";
+                            return "return r3";
                         }
                     }
                 }
-                return "return;";
+                return "return";
             },
             cmplw: function(instr, context) {
                 return _compare(instr, context, "int32_t");
@@ -662,90 +662,90 @@ module.exports = (function() {
             },
             dcbz: function(instr) {
                 if (instr.parsed[1] == "0") {
-                    return "_dcbz (" + instr.parsed[2] + ");";
+                    return "_dcbz (" + instr.parsed[2] + ")";
                 }
-                return "_dcbz (" + instr.parsed[1] + " + " + instr.parsed[2] + ");";
+                return "_dcbz (" + instr.parsed[1] + " + " + instr.parsed[2] + ")";
             },
             mtmsrd: function(instr) {
-                return '_mtmsrd (' + instr.parsed[1] + ');';
+                return '_mtmsrd (' + instr.parsed[1] + ')';
             },
             mfmsrd: function(instr) {
-                return instr.parsed[1] + ' = (uint64_t) _mfmsrd ();';
+                return instr.parsed[1] + ' = (uint64_t) _mfmsrd ()';
             },
             mfcr: function(instr) {
-                return instr.parsed[1] + ' = _mfcr ();';
+                return instr.parsed[1] + ' = _mfcr ()';
             },
             mtcr: function(instr) {
-                return '_mtcr (' + instr.parsed[1] + ');';
+                return '_mtcr (' + instr.parsed[1] + ')';
             },
             mtctr: function(instr) {
-                return 'ctr = ' + instr.parsed[1] + ';';
+                return 'ctr = ' + instr.parsed[1];
             },
             mfctr: function(instr) {
-                return instr.parsed[1] + ' = ctr;';
+                return instr.parsed[1] + ' = ctr';
             },
             mtcrf: function(instr) {
-                return '_mtcrf (' + instr.parsed[1] + ', ' + instr.parsed[2] + ');';
+                return '_mtcrf (' + instr.parsed[1] + ', ' + instr.parsed[2] + ')';
             },
             mflr: function(instr) {
-                return instr.parsed[1] + ' = _mflr ();';
+                return instr.parsed[1] + ' = _mflr ()';
             },
             mtocrf: function(instr) {
-                return '_mtocrf (' + instr.parsed[1] + ', ' + instr.parsed[2] + ');';
+                return '_mtocrf (' + instr.parsed[1] + ', ' + instr.parsed[2] + ')';
             },
             mfpvr: function(instr) {
-                return instr.parsed[1] + ' = _mfpvr ();';
+                return instr.parsed[1] + ' = _mfpvr ()';
             },
             mfdccr: function(instr) {
-                return instr.parsed[1] + ' = _mfdccr ();';
+                return instr.parsed[1] + ' = _mfdccr ()';
             },
             mtdccr: function(instr) {
-                return '_mtdccr (' + instr.parsed[1] + ');';
+                return '_mtdccr (' + instr.parsed[1] + ')';
             },
             mfspr: function(instr) {
                 instr.comments.push("SPR num: " + parseInt(e[2]));
                 var spr = get_spr(instr.parsed[2]);
                 var bits = get_bits(spr);
-                return instr.parsed[1] + ' = (' + bits + ') _mfspr (' + spr + ');';
+                return instr.parsed[1] + ' = (' + bits + ') _mfspr (' + spr + ')';
             },
             mtspr: function(instr) {
                 instr.comments.push("SPR num: " + parseInt(instr.parsed[1]));
                 var spr = get_spr(instr.parsed[1]);
                 var bits = get_bits(spr);
-                return '_mtspr (' + spr + ', ' + instr.parsed[2] + ');';
+                return '_mtspr (' + spr + ', ' + instr.parsed[2] + ')';
             },
             sync: function() {
-                return "_isync ();";
+                return "_isync ()";
             },
             lwsync: function() {
-                return "_lwsync ();";
+                return "_lwsync ()";
             },
             isync: function() {
-                return "_isync ();";
+                return "_isync ()";
             },
             slbia: function() {
-                return "_slbia ();";
+                return "_slbia ()";
             },
             eieio: function() {
-                return "_eieio ();";
+                return "_eieio ()";
             },
             li: function(instr) {
-                return instr.parsed[1] + " = " + instr.parsed[2] + ";";
+                return instr.parsed[1] + " = " + instr.parsed[2];
             },
             lis: function(instr) {
                 if (instr.parsed[2] == '0') {
-                    return instr.parsed[1] + " = 0;";
+                    return instr.parsed[1] + " = 0";
                 }
-                return instr.parsed[1] + " = " + instr.parsed[2] + "0000;";
+                return instr.parsed[1] + " = " + instr.parsed[2] + "0000";
             },
             mr: function(instr) {
-                return instr.parsed[1] + " = " + instr.parsed[2] + ";";
+                return instr.parsed[1] + " = " + instr.parsed[2];
             },
             neg: function(instr) {
-                return instr.parsed[1] + " = -" + instr.parsed[2] + ";";
+                return instr.parsed[1] + " = -" + instr.parsed[2];
             },
             not: function(instr) {
-                return instr.parsed[1] + " = !" + instr.parsed[2] + ";";
+                return instr.parsed[1] + " = !" + instr.parsed[2];
             },
             add: function(instr) {
                 return op_bits4(instr.parsed, "+");
@@ -829,7 +829,7 @@ module.exports = (function() {
                  */
                 var ret = instr.parsed[1];
                 var reg = instr.parsed[2];
-                return ret + " = (uint64_t) _cntlz(" + reg + ");";
+                return ret + " = (uint64_t) _cntlz(" + reg + ")";
             },
             cntlzw: function(instr) {
                 /*
@@ -842,16 +842,16 @@ module.exports = (function() {
                  */
                 var ret = instr.parsed[1];
                 var reg = instr.parsed[2];
-                return ret + " = (uint32_t) _cntlzw(" + reg + ");";
+                return ret + " = (uint32_t) _cntlzw(" + reg + ")";
             },
             extsb: function(instr) {
-                return instr.parsed[1] + " = (int64_t) " + instr.parsed[2] + ";";
+                return instr.parsed[1] + " = (int64_t) " + instr.parsed[2];
             },
             extsh: function(instr) {
-                return instr.parsed[1] + " = (int64_t) " + instr.parsed[2] + ";";
+                return instr.parsed[1] + " = (int64_t) " + instr.parsed[2];
             },
             extsw: function(instr) {
-                return instr.parsed[1] + " = (int64_t) " + instr.parsed[2] + ";";
+                return instr.parsed[1] + " = (int64_t) " + instr.parsed[2];
             },
             /*
 to be redone. this is wrong.
@@ -862,16 +862,16 @@ rldicl %r0, %r0, 0,59     # %r0 = %r0 & 0x1F
 rldicl %r9, %r9, 61,3     # %r9 = (%r9 >> 3) & 0x1FFFFFFFFFFFFFFF
 */
             rldic: function(instr) {
-                return instr.parsed[1] + ' = rol64(' + instr.parsed[2] + ', ' + instr.parsed[3] + ') & ' + instr.parsed[4] + ';';
+                return instr.parsed[1] + ' = rol64(' + instr.parsed[2] + ', ' + instr.parsed[3] + ') & ' + instr.parsed[4];
             },
             rldcl: function(instr) {
-                return instr.parsed[1] + ' = rol64(' + instr.parsed[2] + ', ' + instr.parsed[3] + ') & ' + instr.parsed[4] + ';';
+                return instr.parsed[1] + ' = rol64(' + instr.parsed[2] + ', ' + instr.parsed[3] + ') & ' + instr.parsed[4];
             },
             rldicl: function(instr) {
-                return instr.parsed[1] + ' = rol64(' + instr.parsed[2] + ', ' + instr.parsed[3] + ') & ' + instr.parsed[4] + ';';
+                return instr.parsed[1] + ' = rol64(' + instr.parsed[2] + ', ' + instr.parsed[3] + ') & ' + instr.parsed[4];
             },
             rldcr: function(instr) {
-                return instr.parsed[1] + ' = rol64(' + instr.parsed[2] + ', ' + instr.parsed[3] + ') & ' + instr.parsed[4] + ';';
+                return instr.parsed[1] + ' = rol64(' + instr.parsed[2] + ', ' + instr.parsed[3] + ') & ' + instr.parsed[4];
             },
             rldicr: function(instr) {
                 var res = instr.parsed[1] + ' = ';
@@ -880,7 +880,7 @@ rldicl %r9, %r9, 61,3     # %r9 = (%r9 >> 3) & 0x1FFFFFFFFFFFFFFF
                 var mb = 0;
                 var me = parseInt(instr.parsed[4]);
                 var mask = mask64(mb, me);
-                return res + ';';
+                return res;
             },
             clrlwi: function(instr) {
                 var res = instr.parsed[1];

--- a/libdec/core/Analyzer.js
+++ b/libdec/core/Analyzer.js
@@ -16,6 +16,7 @@
  */
 
 module.exports = (function() {
+    var Base = require('../arch/base');
     const cfg = require('../config');
     var Flow = require('./Flow');
     var Scope = require('./Scope');
@@ -57,7 +58,7 @@ module.exports = (function() {
             if (fcn) {
                 instr.pseudo = fcn(instr, context, instructions);
             } else {
-                instr.pseudo = cfg.anal.asmheader + opcode + cfg.anal.asmtrailer;
+                instr.pseudo = Base.unknown(opcode);
             }
         }
     };

--- a/libdec/core/Flow.js
+++ b/libdec/core/Flow.js
@@ -29,7 +29,7 @@ module.exports = (function() {
         this.hi = hi;
 
         this.isInside = function(addr) {
-            return addr.gte(this.low) && addr.lte(this.hi);
+            return addr ? (addr.gte(this.low) && addr.lte(this.hi)) : false;
         }
     };
 
@@ -46,7 +46,7 @@ module.exports = (function() {
             return false;
         }
         if (!instr.pseudo) {
-            instr.pseudo = 'goto 0x' + instr.jump.toString(16) + ';'
+            instr.pseudo = 'goto 0x' + instr.jump.toString(16);
         }
         return true;
     };
@@ -65,7 +65,7 @@ module.exports = (function() {
     var _set_label = function(instructions, index) {
         var label = _label_counter++;
         var instr = instructions[index];
-        instr.pseudo = 'goto label_' + label + ';';
+        instr.pseudo = 'goto label_' + label;
         for (var i = index; i < instructions.length; i++) {
             var tmpinstr = instructions[i];
             if (tmpinstr.loc.eq(instr.jump)) {
@@ -88,8 +88,9 @@ module.exports = (function() {
                 return false;
             }
             var start = instructions.indexOf(tmpinstr);
+            var is_while = (instructions[start - 1] && bounds.isInside(instructions[start - 1].jump));
             scope.level = instructions[start].scope.level + 1;
-            scope.header = 'do {';
+            scope.header = is_while ? ('while (' + cond + ') {') : 'do {';
             for (var i = start; i <= index; i++) {
                 tmpinstr = instructions[i];
                 if (tmpinstr.scope.level == scope.level) {
@@ -105,7 +106,7 @@ module.exports = (function() {
                     }
                 }
             }
-            scope.trailer = '} while (' + cond + ');';
+            scope.trailer = is_while ? '}' : '} while (' + cond + ');';
             return true;
         }
         return false;

--- a/libdec/core/Instruction.js
+++ b/libdec/core/Instruction.js
@@ -32,6 +32,7 @@ module.exports = (function() {
         this.comments = op.comment ? [(Buffer.from(op.comment, 'base64').toString())] : [];
         this.pseudo = this.opcode; //null;
         this.parsed = null;
+        this.valid = true;
         this.string = null;
         this.cond = null;
         this.xrefs = op.xrefs ? op.xrefs.slice() : [];
@@ -47,8 +48,8 @@ module.exports = (function() {
                     p(ident + ' */');
                 }
             }
-            if (this.pseudo) {
-                p(ident + this.pseudo);
+            if (this.pseudo && this.valid) {
+                p(ident + this.pseudo.toString() + ';');
             }
         };
         this.conditional = function(a, b, type) {

--- a/libdec/core/Routine.js
+++ b/libdec/core/Routine.js
@@ -30,6 +30,20 @@ module.exports = (function() {
         this.name = name ? name.replace(cfg.anal.replace, '') : 'unknown_fcn';
 
         this.print = function(p) {
+            var macros = [];
+            for (var i = 0; i < this.instructions.length; i++) {
+                if (!this.instructions[i].pseudo || !this.instructions[i].pseudo.deps) {
+                    continue;
+                }
+                for (var j = 0; j < this.instructions[i].pseudo.deps.macros.length; j++) {
+                    if (macros.indexOf(this.instructions[i].pseudo.deps.macros[j]) < 0) {
+                        macros.push(this.instructions[i].pseudo.deps.macros[j])
+                    }
+                }
+            }
+            for (var i = 0; i < macros.length; i++) {
+                p(macros[i]);
+            }
             var current = this.instructions[0].scope;
             var scopes = [current];
             var ident = cfg.ident;

--- a/libdec/core/Routine.js
+++ b/libdec/core/Routine.js
@@ -20,6 +20,33 @@ module.exports = (function() {
     var Flow = require('./Flow');
     var Scope = require('./Scope');
 
+    var _print_deps = function(p, instructions) {
+        var macros = [];
+        var codes = [];
+        for (var i = 0; i < instructions.length; i++) {
+            if (!instructions[i].pseudo || !instructions[i].pseudo.deps) {
+                continue;
+            }
+            for (var j = 0; j < instructions[i].pseudo.deps.macros.length; j++) {
+                if (macros.indexOf(instructions[i].pseudo.deps.macros[j]) < 0) {
+                    macros.push(instructions[i].pseudo.deps.macros[j]);
+                    if (instructions[i].pseudo.deps.code.length > 0) {
+                        codes.push(instructions[i].pseudo.deps.code);
+                    }
+                }
+            }
+        }
+        for (var i = 0; i < macros.length; i++) {
+            p(macros[i]);
+        }
+        if (macros.length) {
+            p('');
+        }
+        for (var i = 0; i < codes.length; i++) {
+            p(codes[i] + '\n');
+        }
+    };
+
     /*
      * Expects name and instructions as input.
      */
@@ -30,20 +57,7 @@ module.exports = (function() {
         this.name = name ? name.replace(cfg.anal.replace, '') : 'unknown_fcn';
 
         this.print = function(p) {
-            var macros = [];
-            for (var i = 0; i < this.instructions.length; i++) {
-                if (!this.instructions[i].pseudo || !this.instructions[i].pseudo.deps) {
-                    continue;
-                }
-                for (var j = 0; j < this.instructions[i].pseudo.deps.macros.length; j++) {
-                    if (macros.indexOf(this.instructions[i].pseudo.deps.macros[j]) < 0) {
-                        macros.push(this.instructions[i].pseudo.deps.macros[j])
-                    }
-                }
-            }
-            for (var i = 0; i < macros.length; i++) {
-                p(macros[i]);
-            }
+            _print_deps(p, this.instructions);
             var current = this.instructions[0].scope;
             var scopes = [current];
             var ident = cfg.ident;


### PR DESCRIPTION
Now decompiles like this
Example of `x86`
```c
#include <stdio.h>

void main () {
    *((int32_t*) local_4h) = edi;
    *((int64_t*) local_10h) = rsi;
    puts ("hello world");
    eax = 0;
    return eax;
}
```