### PR TITLE
_find_bits function now takes R8L-R15L, R8W-R15W and R8D-R15D into account

### DIFF
--- a/libdec/arch/x86.js
+++ b/libdec/arch/x86.js
@@ -65,6 +65,14 @@ module.exports = (function() {
         reg = reg.toLowerCase();
         var c = reg.charAt(0);
         if (c == 'r') {
+            var suffix = reg.charAt(reg.length - 1);
+            if (suffix == 'l') {
+                return 8;
+            } else if (suffix == 'w') {
+                return 16;
+            } else if (suffix == 'd') {
+                return 32;
+            }
             return 64;
         } else if (c == 'e') {
             return 32;


### PR DESCRIPTION
The "_find_bits" function treated all x86-64 registers that start with an 'R' as 64 bits regs, overlooking R8-R15 potential suffixes.