### PR TITLE
Add pddj for JSON output

### DIFF
--- a/libdec/context.js
+++ b/libdec/context.js
@@ -29,7 +29,7 @@
         this.printLine = function(str, offset) {
             var line = { str: str, offset: offset };
             this.lines.push(line);
-        }
+        };
 
         /**
          * Print a line for logging.
@@ -46,7 +46,7 @@
             } else {
                 console.log(str);
             }
-        }
+        };
 
         /**
          * Internal C macro list.

--- a/libdec/context.js
+++ b/libdec/context.js
@@ -17,15 +17,36 @@
 
 (function() {
     return function() {
+        this.lines = [];
+        this.errors = [];
+        this.log = [];
+
         /**
          * Print a line of decompiled code.
-         * @param - str content of the line
+         * @param str - content of the line
          * @param offset - offset of the original instruction (optional)
          */
         this.printLine = function(str, offset) {
-            console.log(str);
+            var line = { str: str, offset: offset };
+            this.lines.push(line);
         }
 
+        /**
+         * Print a line for logging.
+         * @param str - content to print
+         * @param error - boolean whether this is an error (optional)
+         */
+        this.printLog = function(str, error) {
+            if (Global.evars.extra.json) {
+                if(error) {
+                    this.errors.push(str);
+                } else {
+                    this.log.push(str);
+                }
+            } else {
+                console.log(str);
+            }
+        }
 
         /**
          * Internal C macro list.

--- a/libdec/context.js
+++ b/libdec/context.js
@@ -18,6 +18,16 @@
 (function() {
     return function() {
         /**
+         * Print a line of decompiled code.
+         * @param - str content of the line
+         * @param offset - offset of the original instruction (optional)
+         */
+        this.printLine = function(str, offset) {
+            console.log(str);
+        }
+
+
+        /**
          * Internal C macro list.
          * @type {Array}
          */
@@ -40,10 +50,10 @@
             if (!Global.evars.honor.blocks) {
                 var t = Global.printer.theme;
                 for (var i = 0; i < this.macros.length; i++) {
-                    console.log(this.identfy() + t.macro(this.macros[i]));
+                    this.printLine(this.identfy() + t.macro(this.macros[i]));
                 }
             }
-            console.log(this.identfy() + ' ');
+            this.printLine(this.identfy() + ' ');
         };
 
         /**
@@ -74,7 +84,7 @@
                 x.print();
             });
             if (this.dependencies.length > 0) {
-                console.log(this.identfy() + ' ');
+                this.printLine(this.identfy() + ' ');
             }
         };
 

--- a/libdec/core.js
+++ b/libdec/core.js
@@ -100,7 +100,7 @@
                 break;
             }
             var fcn = arch.instructions[instr.parsed.mnem];
-            // console.log(instr.assembly)
+            // Global.context.printLine(instr.assembly)
             instr.code = fcn ? fcn(instr, arch_context, instructions) : new Base.unknown(instr.assembly);
         }
     };
@@ -126,8 +126,8 @@
         var t = Global.printer.theme;
         var asm_header = Global.evars.honor.offsets ? '' : '; assembly';
         var details = '/* ' + Global.evars.extra.file + ' @ 0x' + Global.evars.extra.offset.toString(16) + ' */';
-        console.log(Global.context.identfy(asm_header.length, t.comment(asm_header)) + t.comment('/* r2dec pseudo code output */'));
-        console.log(Global.context.identfy() + t.comment(details));
+        Global.context.printLine(Global.context.identfy(asm_header.length, t.comment(asm_header)) + t.comment('/* r2dec pseudo code output */'));
+        Global.context.printLine(Global.context.identfy() + t.comment(details));
         if (['java', 'dalvik'].indexOf(Global.evars.arch) < 0) {
             Global.context.printMacros();
             Global.context.printDependencies();
@@ -135,7 +135,7 @@
         session.print();
         while (Global.context.ident.length > 0) {
             Global.context.identOut();
-            console.log(Global.context.identfy() + '}');
+            Global.context.printLine(Global.context.identfy() + '}');
         }
     };
 

--- a/libdec/core.js
+++ b/libdec/core.js
@@ -111,16 +111,16 @@
      */
     var _print = function(session) {
         if (!session.routine) {
-            console.log('Error: no "good" data given (all invalid opcodes).');
+            Global.context.printLog('Error: no "good" data given (all invalid opcodes).', true);
             return;
         }
         if (Global.evars.extra.ascomment) {
             session.ascomment();
-            console.log('[r2dec] comments applied for "' + session.routine_name + '".');
+            Global.context.printLog('[r2dec] comments applied for "' + session.routine_name + '".');
             return;
         } else if (Global.evars.extra.ascodeline) {
             session.ascodeline();
-            console.log('[r2dec] new code lines applied for "' + session.routine_name + '".');
+            Global.context.printLog('[r2dec] new code lines applied for "' + session.routine_name + '".');
             return;
         }
         var t = Global.printer.theme;

--- a/libdec/core/instruction.js
+++ b/libdec/core/instruction.js
@@ -70,12 +70,12 @@
             b = Global.printer.auto;
             addr = Extra.align_address(instr.location);
             if (instr.code && instr.code.composed) {
-                console.log(Global.context.identfy(addr.length, t.integers(addr)) + instr.code.composed[0] + ';');
+                Global.context.printLine(Global.context.identfy(addr.length, t.integers(addr)) + instr.code.composed[0] + ';', instr.location);
                 for (i = 1; i < instr.code.composed.length; i++) {
-                    console.log(Global.context.identfy(addr.length, t.integers(addr)) + instr.code.composed[i] + ';');
+                    Global.context.printLine(Global.context.identfy(addr.length, t.integers(addr)) + instr.code.composed[i] + ';', instr.location);
                 }
             } else if (_printable(instr)) {
-                console.log(Global.context.identfy(addr.length, t.integers(addr)) + instr.code + ';');
+                Global.context.printLine(Global.context.identfy(addr.length, t.integers(addr)) + instr.code + ';', instr.location);
             }
         } else if (Global.evars.honor.assembly) {
             t = Global.printer.theme;
@@ -83,20 +83,20 @@
             addr = Extra.align_address(instr.location);
             s = 1 + addr.length + instr.simplified.length;
             if (instr.code && instr.code.composed) {
-                console.log(Global.context.identfy(s, t.integers(addr) + ' ' + b(instr.simplified)) + instr.code.composed[0] + ';');
+                Global.context.printLine(Global.context.identfy(s, t.integers(addr) + ' ' + b(instr.simplified)) + instr.code.composed[0] + ';', instr.location);
                 for (i = 1; i < instr.code.composed.length; i++) {
-                    console.log(Global.context.identfy() + instr.code.composed[i] + ';');
+                    Global.context.printLine(Global.context.identfy() + instr.code.composed[i] + ';', instr.location);
                 }
             } else {
-                console.log(Global.context.identfy(s, t.integers(addr) + ' ' + b(instr.simplified)) + (_printable(instr) ? (instr.code + ';') : ''));
+                Global.context.printLine(Global.context.identfy(s, t.integers(addr) + ' ' + b(instr.simplified)) + (_printable(instr) ? (instr.code + ';') : ''), instr.location);
             }
         } else {
             if (instr.code && instr.code.composed) {
                 for (i = 0; i < instr.code.composed.length; i++) {
-                    console.log(Global.context.identfy() + instr.code.composed[i] + ';');
+                    Global.context.printLine(Global.context.identfy() + instr.code.composed[i] + ';', instr.location);
                 }
             } else if (_printable(instr)) {
-                console.log(Global.context.identfy() + instr.code + ';');
+                Global.context.printLine(Global.context.identfy() + instr.code + ';', instr.location);
             }
         }
     };
@@ -147,15 +147,15 @@
             var t = Global.printer.theme;
             var empty = Global.context.identfy();
             if (this.comments.length == 1) {
-                console.log(empty + t.comment('/* ' + this.comments[0] + ' */'));
+                Global.context.printLine(empty + t.comment('/* ' + this.comments[0] + ' */', this.location));
             } else if (this.comments.length > 1) {
-                console.log(empty + t.comment('/* ' + this.comments[0]));
+                Global.context.printLine(empty + t.comment('/* ' + this.comments[0]), this.location);
                 for (var i = 1; i < this.comments.length; i++) {
-                    console.log(empty + t.comment(' * ' + this.comments[i] + (i == this.comments.length - 1 ? ' */' : '')));
+                    Global.context.printLine(empty + t.comment(' * ' + this.comments[i] + (i == this.comments.length - 1 ? ' */' : '')), this.location);
                 }
             }
             if (this.label) {
-                console.log(Global.context.identfy(null, null, true) + this.label + ':');
+                Global.context.printLine(Global.context.identfy(null, null, true) + this.label + ':', this.location);
             }
             _asm_view(this);
         };

--- a/libdec/core/macro.js
+++ b/libdec/core/macro.js
@@ -21,7 +21,7 @@
 		this.print = function() {
 			var t = Global.printer.theme;
 			for (var i = 0; i < this.data.length; i++) {
-				console.log(Global.context.identfy() + t.macro(this.data[i]));
+				Global.context.printLine(Global.context.identfy() + t.macro(this.data[i]));
 			}
 		};
 	};

--- a/libdec/core/scope.js
+++ b/libdec/core/scope.js
@@ -20,17 +20,17 @@
 
     var __debug = false;
 
-    var _print_locals = function(locals, spaced) {
+    var _print_locals = function(locals, address, spaced) {
         if (Global.evars.honor.blocks) {
             return;
         }
         var a = Global.printer.auto;
         for (var i = 0; i < locals.length; i++) {
             var local = Extra.is.string(locals[i]) ? a(locals[i]) : locals[i].toString(true);
-            console.log(Global.context.identfy() + local + ';');
+            Global.context.printLine(Global.context.identfy() + local + ';', address);
         }
         if (spaced && locals.length > 0) {
-            console.log(Global.context.identfy());
+            Global.context.printLine(Global.context.identfy(), address);
         }
     };
 
@@ -39,7 +39,7 @@
             var t = Global.printer.theme;
             var ident = Global.context.identfy();
             var addr = block.address.toString(16);
-            console.log(ident + t.comment('/* address 0x' + addr + ' */'));
+            Global.context.printLine(ident + t.comment('/* address 0x' + addr + ' */'));
         }
     };
 
@@ -52,7 +52,7 @@
             this.print = function() {
                 Global.context.identOut();
                 var offset = Global.evars.honor.offsets ? Extra.align_address(this.address) : '';
-                console.log(Global.context.identfy(offset.length, Global.printer.theme.integers(offset)) + this.toString());
+                Global.context.printLine(Global.context.identfy(offset.length, Global.printer.theme.integers(offset)) + this.toString(), this.address);
             };
         },
         custom: function(address, colorname) {
@@ -63,7 +63,7 @@
             };
             this.print = function() {
                 var offset = Global.evars.honor.offsets ? Extra.align_address(this.address) : '';
-                console.log(Global.context.identfy(offset.length, Global.printer.theme.integers(offset)) + this.toString());
+                Global.context.printLine(Global.context.identfy(offset.length, Global.printer.theme.integers(offset)) + this.toString(), this.address);
                 Global.context.identIn();
                 _print_block_data(this);
             };
@@ -82,14 +82,14 @@
             this.print = function() {
                 var e = this.extra;
                 var t = Global.printer.theme;
-                _print_locals(e.globals, true);
+                _print_locals(e.globals, this.address, true);
                 var asmname = Global.evars.honor.offsets ? Extra.align_address(this.address) : '; (fcn) ' + e.name + ' ()';
                 var color = Global.evars.honor.offsets ? 'integers' : 'comment';
                 var ident = Global.context.identfy(asmname.length, t[color](asmname));
-                console.log(ident + this.toString());
+                Global.context.printLine(ident + this.toString(), this.address);
                 Global.context.identIn();
                 _print_block_data(this);
-                _print_locals(e.locals);
+                _print_locals(e.locals, this.address);
             };
         },
         if: function(address, condition, locals) {
@@ -102,10 +102,10 @@
             };
             this.print = function() {
                 var offset = Global.evars.honor.offsets ? Extra.align_address(this.address) : '';
-                console.log(Global.context.identfy(offset.length, Global.printer.theme.integers(offset)) + this.toString());
+                Global.context.printLine(Global.context.identfy(offset.length, Global.printer.theme.integers(offset)) + this.toString(), this.address);
                 Global.context.identIn();
                 _print_block_data(this);
-                _print_locals(this.locals);
+                _print_locals(this.locals, this.address);
             };
         },
         else: function(address, locals) {
@@ -119,10 +119,10 @@
             this.print = function() {
                 Global.context.identOut();
                 var offset = Global.evars.honor.offsets ? Extra.align_address(this.address) : '';
-                console.log(Global.context.identfy(offset.length, Global.printer.theme.integers(offset)) + this.toString());
+                Global.context.printLine(Global.context.identfy(offset.length, Global.printer.theme.integers(offset)) + this.toString());
                 Global.context.identIn();
                 _print_block_data(this);
-                _print_locals(this.locals);
+                _print_locals(this.locals, this.address);
             };
         },
         do: function(address, locals) {
@@ -133,10 +133,10 @@
                 return t.flow('do') + ' {' + (__debug ? t.comment(' // 0x' + this.address.toString(16)) : '');
             };
             this.print = function() {
-                console.log(Global.context.identfy() + this.toString());
+                Global.context.printLine(Global.context.identfy() + this.toString(), this.address);
                 Global.context.identIn();
                 _print_block_data(this);
-                _print_locals(this.locals);
+                _print_locals(this.locals, this.address);
             };
         },
         while: function(address, condition, locals) {
@@ -149,10 +149,10 @@
             };
             this.print = function() {
                 var offset = Global.evars.honor.offsets ? Extra.align_address(this.address) : '';
-                console.log(Global.context.identfy(offset.length, Global.printer.theme.integers(offset)) + this.toString());
+                Global.context.printLine(Global.context.identfy(offset.length, Global.printer.theme.integers(offset)) + this.toString(), this.address);
                 Global.context.identIn();
                 _print_block_data(this);
-                _print_locals(this.locals);
+                _print_locals(this.locals, this.address);
             };
         },
         whileEnd: function(address, condition) {
@@ -164,7 +164,7 @@
             };
             this.print = function() {
                 Global.context.identOut();
-                console.log(Global.context.identfy() + this.toString());
+                Global.context.printLine(Global.context.identfy() + this.toString(), this.address);
             };
         },
         whileInline: function(address, condition) {
@@ -177,7 +177,7 @@
             this.print = function() {
                 _print_block_data(this);
                 var offset = Global.evars.honor.offsets ? Extra.align_address(this.address) : '';
-                console.log(Global.context.identfy(offset.length, Global.printer.theme.integers(offset)) + this.toString());
+                Global.context.printLine(Global.context.identfy(offset.length, Global.printer.theme.integers(offset)) + this.toString(), this.address);
             };
         }
     };

--- a/libdec/db/c_calls.js
+++ b/libdec/db/c_calls.js
@@ -48,11 +48,11 @@
                     var a = Global.printer.auto;
                     var h = Global.printer.html;
                     var t = Global.printer.theme;
-                    console.log(Global.context.identfy() + t.types(type) + h(' ') + t.callname(call) + h(' (') + args + h(' ) {'));
+                    Global.context.printLine(Global.context.identfy() + t.types(type) + h(' ') + t.callname(call) + h(' (') + args + h(' ) {'));
                     for (var i = 0; i < this.data.length; i++) {
-                        console.log(Global.context.identfy() + a(this.data[i].replace(/###/g, this.bits)));
+                        Global.context.printLine(Global.context.identfy() + a(this.data[i].replace(/###/g, this.bits)));
                     }
-                    console.log(Global.context.identfy() + h('}'));
+                    Global.context.printLine(Global.context.identfy() + h('}'));
                 };
             }
         },
@@ -79,11 +79,11 @@
                     var a = Global.printer.auto;
                     var h = Global.printer.html;
                     var t = Global.printer.theme;
-                    console.log(Global.context.identfy() + t.types(type) + h(' ') + t.callname(call) + h(' (') + args + h(' ) {'));
+                    Global.context.printLine(Global.context.identfy() + t.types(type) + h(' ') + t.callname(call) + h(' (') + args + h(' ) {'));
                     for (var i = 0; i < this.data.length; i++) {
-                        console.log(Global.context.identfy() + a(this.data[i].replace(/###/g, this.bits)));
+                        Global.context.printLine(Global.context.identfy() + a(this.data[i].replace(/###/g, this.bits)));
                     }
-                    console.log(Global.context.identfy() + h('}'));
+                    Global.context.printLine(Global.context.identfy() + h('}'));
                 };
             }
         },
@@ -98,7 +98,7 @@
                     }
                     _unique_print.bit_mask = true;
                     var t = Global.printer.theme;
-                    console.log(Global.context.identfy() + t.macro('#define BIT_MASK(t,v) ((t)(-((v)!= 0)))&(((t)-1)>>((sizeof(t)*CHAR_BIT)-(v)))'));
+                    Global.context.printLine(Global.context.identfy() + t.macro('#define BIT_MASK(t,v) ((t)(-((v)!= 0)))&(((t)-1)>>((sizeof(t)*CHAR_BIT)-(v)))'));
                 };
             }
         },
@@ -133,7 +133,7 @@
                     _unique_print.swap_endian.push(this.bits);
                     var t = Global.printer.theme;
                     for (var i = 0; i < this.data.length; i++) {
-                        console.log(Global.context.identfy() + t.macro(this.data[i]));
+                        Global.context.printLine(Global.context.identfy() + t.macro(this.data[i]));
                     }
                 };
             }

--- a/libdec/libdec.js
+++ b/libdec/libdec.js
@@ -21,8 +21,7 @@
 		archs: require('libdec/archs'),
 		context: require('libdec/context'),
 		supported: function() {
-			console.log('Supported architectures:');
-			console.log('    ' + Object.keys(this.archs).join(', '));
+			return 'Supported architectures:\n    ' + Object.keys(this.archs).join(', ');
 		}
 	};
 });

--- a/libdec/printer.js
+++ b/libdec/printer.js
@@ -19,7 +19,6 @@
 /**
  * Imports.
  */
-const Long = require('libdec/long');
 const json64 = require('libdec/json64');
 
 (function() {

--- a/libdec/printer.js
+++ b/libdec/printer.js
@@ -15,6 +15,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+
+/**
+ * Imports.
+ */
+var Long = require('libdec/long');
+
 (function() {
     function initializeColors() {
         const config = {};

--- a/libdec/printer.js
+++ b/libdec/printer.js
@@ -197,6 +197,44 @@
     };
 
     /**
+     * Prints the final r2dec output
+     * @param useJSON - boolean whether to print as json
+     */
+    var _flush_output = function(lines, errors, log, useJSON) {
+        if (useJSON) {
+            var result = {};
+            if (lines && lines.length > 0) {
+                result.lines = lines;
+            }
+            if (errors && errors.length > 0) {
+                result.errors = errors;
+            }
+            if (log && log.length > 0) {
+                result.log = log;
+            }
+            console.log(JSON.stringify(result, function(name, val) {
+                if (Long.isLong(val)) {
+                    return val.toString(10);
+                } else {
+                    return val;
+                }
+            }));
+        } else {
+            if (lines && lines.length > 0) {
+                for (var i = 0; i < lines.length; i++) {
+                    console.log(lines[i].str);
+                }
+            }
+            if (errors && errors.length > 0) {
+                console.log(errors.join("\n"));
+            }
+            if (log && log.length > 0) {
+                console.log(log.join("\n"));
+            }
+        }
+    }
+
+    /**
      * Printer Object
      * @return {Function} - Printer object (to be called via `new Printer()`)
      */
@@ -205,5 +243,6 @@
         this.theme = _theme_colors;
         this.auto = _colorize_text;
         this.html = _htmlize;
+        this.flushOutput = _flush_output;
     };
 });

--- a/libdec/printer.js
+++ b/libdec/printer.js
@@ -19,7 +19,8 @@
 /**
  * Imports.
  */
-var Long = require('libdec/long');
+const Long = require('libdec/long');
+const json64 = require('libdec/json64');
 
 (function() {
     function initializeColors() {
@@ -218,13 +219,7 @@ var Long = require('libdec/long');
             if (log && log.length > 0) {
                 result.log = log;
             }
-            console.log(JSON.stringify(result, function(name, val) {
-                if (Long.isLong(val)) {
-                    return val.toString(10);
-                } else {
-                    return val;
-                }
-            }));
+            console.log(json64.stringify(result));
         } else {
             if (lines && lines.length > 0) {
                 for (var i = 0; i < lines.length; i++) {

--- a/libdec/printer.js
+++ b/libdec/printer.js
@@ -238,7 +238,7 @@ var Long = require('libdec/long');
                 console.log(log.join("\n"));
             }
         }
-    }
+    };
 
     /**
      * Printer Object

--- a/libdec/r2util.js
+++ b/libdec/r2util.js
@@ -268,8 +268,7 @@
             if (evars.extra.debug) {
                 return 'Exception:', exception.stack;
             } else {
-                return
-                    '\n\nr2dec has crashed (info: ' + r2pipe.string('i~^file[1:0]') + ' @ ' + r2pipe.string('s') + ').\n' +
+                return '\n\nr2dec has crashed (info: ' + r2pipe.string('i~^file[1:0]') + ' @ ' + r2pipe.string('s') + ').\n' +
                     'Please report the bug at https://github.com/wargio/r2dec-js/issues\n' +
                     'Use the option \'--issue\' or the command \'pddi\' to generate \n' +
                     'the needed data for the issue.';

--- a/libdec/r2util.js
+++ b/libdec/r2util.js
@@ -266,7 +266,7 @@
         debug: function(evars, exception) {
             r2util.sanitize(false, evars);
             if (evars.extra.debug) {
-                return 'Exception:', exception.stack;
+                return 'Exception: ' + exception.stack;
             } else {
                 return '\n\nr2dec has crashed (info: ' + r2pipe.string('i~^file[1:0]') + ' @ ' + r2pipe.string('s') + ').\n' +
                     'Please report the bug at https://github.com/wargio/r2dec-js/issues\n' +

--- a/libdec/r2util.js
+++ b/libdec/r2util.js
@@ -76,6 +76,7 @@
         "--xrefs": "shows also instruction xrefs in the pseudo code",
         "--as-comment": "the decompiled code is returned to r2 as comment (via CCu)",
         "--as-code-line": "the decompiled code is returned to r2 as 'file:line code' (via CL)",
+        "--as-json": "the decompiled code lines are returned as JSON"
     };
 
     function has_option(args, name) {
@@ -212,6 +213,7 @@
                 offset: r2pipe.long('s'),
                 ascomment: has_option(args, '--as-comment'),
                 ascodeline: has_option(args, '--as-code-line'),
+                json: has_option(args, '--as-json'),
                 debug: r2pipe.bool('e r2dec.debug') || has_option(args, '--debug'),
                 slow: r2pipe.bool('e r2dec.slow')
             };
@@ -264,14 +266,13 @@
         debug: function(evars, exception) {
             r2util.sanitize(false, evars);
             if (evars.extra.debug) {
-                console.log('Exception:', exception.stack);
+                return 'Exception:', exception.stack;
             } else {
-                console.log(
+                return
                     '\n\nr2dec has crashed (info: ' + r2pipe.string('i~^file[1:0]') + ' @ ' + r2pipe.string('s') + ').\n' +
                     'Please report the bug at https://github.com/wargio/r2dec-js/issues\n' +
                     'Use the option \'--issue\' or the command \'pddi\' to generate \n' +
-                    'the needed data for the issue.'
-                );
+                    'the needed data for the issue.';
             }
         }
     };

--- a/libdec/warning.js
+++ b/libdec/warning.js
@@ -22,7 +22,7 @@
 			if (this.printer.theme.comment) {
 				message = this.printer.theme.comment(message);
 			}
-			console.log(message);
+			this.context.printLog(message);
 		}
 	};
 });

--- a/p/core_pdd.c
+++ b/p/core_pdd.c
@@ -170,6 +170,7 @@ static void usage(const RCore* const core) {
 		"pdda",	"",        "decompile current function with side assembly",
 		"pddb",	"",        "decompile current function but show only scopes",
 		"pddo",	"",        "decompile current function side by side with offsets",
+		"pddj", "",        "decompile current function as json",
 		"pddu",	"",        "upgrade r2dec via r2pm",
 		"pdds", " branch", "switch r2dec branch",
 		"pddi",	"",        "generate issue data",
@@ -249,6 +250,10 @@ static void _cmd_pdd(RCore *core, const char *input) {
 	case '*':
 		// --as-comment
 		duk_r2dec (core, "--as-comment");
+		break;
+	case 'j':
+		// --as-json
+		duk_r2dec (core, "--as-json");
 		break;
 	case '?':
 	default:

--- a/r2dec-duk.js
+++ b/r2dec-duk.js
@@ -42,7 +42,6 @@ var Global = {
  */
 var libdec = require('libdec/libdec');
 var r2util = require('libdec/r2util');
-var Long = require('libdec/long');
 
 /**
  * r2dec main function.

--- a/r2dec-duk.js
+++ b/r2dec-duk.js
@@ -98,35 +98,9 @@ function r2dec_main(args) {
         errors.push(r2util.debug(Global.evars, e));
     }
 
-    if (useJSON) {
-        var result = {};
-        if (lines && lines.length > 0) {
-            result.lines = lines;
-        }
-        if (errors && errors.length > 0) {
-            result.errors = errors;
-        }
-        if (log && log.length > 0) {
-            result.log = log;
-        }
-        console.log(JSON.stringify(result, function(name, val) {
-            if (Long.isLong(val)) {
-                return val.toString(10);
-            } else {
-                return val;
-            }
-        }));
-    } else {
-        if (lines && lines.length > 0) {
-            for (var i = 0; i < lines.length; i++) {
-                console.log(lines[i].str);
-            }
-        }
-        if (errors && errors.length > 0) {
-            console.log(errors.join("\n"));
-        }
-        if (log && log.length > 0) {
-            console.log(log.join("\n"));
-        }
+    var printer = Global.printer;
+    if (!printer) {
+        printer = new Printer();
     }
+    printer.flushOutput(lines, errors, log, useJSON);
 }

--- a/r2dec-test.js
+++ b/r2dec-test.js
@@ -68,6 +68,7 @@ function r2dec_main(filename) {
                 libdec.core.decompile(p, architecture, arch_context);
                 libdec.core.analysis.post(p, architecture, arch_context);
                 libdec.core.print(p);
+                Global.printer.flushOutput(Global.context.lines, Global.context.errors, Global.context.log, Global.evars.extra.json);
             } else {
                 console.log('Error: no data available.\nPlease analyze the function/binary first.');
             }


### PR DESCRIPTION
This might still have a few issues, but I'll just wait for travis.

Also, right now I am printing the custom long objects as Strings, like this:
```
{
      "str": "\u001b[38;2;255;213;128muint64_t\u001b[39m \u001b[38;2;80;208;224mfcn_00005ec0\u001b[39m (\u001b[38;2;255;213;128mint32_t\u001b[39m arg1) {",
      "offset": "24256"
}
```
But I would prefer to have them as actual JSON ints (converting them to Number obv doesn't work for 64 bit). @wargio Do you know any good way to do this?

Example of the output:
![Bildschirmfoto vom 2019-07-11 11-16-29](https://user-images.githubusercontent.com/1460997/61038438-5919d880-a3cd-11e9-92f9-3cfecf76c494.png)
