### PR TITLE
invalid callee.calltype on x86

### DIFF
--- a/libdec/arch/x86.js
+++ b/libdec/arch/x86.js
@@ -941,8 +941,11 @@
                 'amd64': _populate_systemv_amd64_call_args,
                 'ms': _populate_ms_amd64_call_args
             }[callee.calltype];
-            if (typeof populate_call_args === 'undefined') {
+            if (!populate_call_args) {
               populate_call_args = _populate_cdecl_call_args;
+            }
+            if (!guess_nargs) {
+              guess_nargs = _guess_cdecl_nargs;
             }
 
             // every non-import callee has a known number of arguments


### PR DESCRIPTION
```
    ; assembly                                       | /* r2dec pseudo code output */
                                                     | /* testsuite @ 0x0 */
                                                     | #include <stdint.h>
                                                     |  
    ; (fcn) main ()                                  | int32_t main (void) {
                                                     |     uint32_t var_ch;
                                                     |     int32_t var_8h;
                                                     |     int32_t var_4h;
                                                     |     int32_t var_sp_4h;
    0x080483e4 push ebp                              |     
    0x080483e5 mov ebp, esp                          |     
    0x080483e7 sub esp, 0x18                         |     
    0x080483ea and esp, 0xfffffff0                   |     
    0x080483ed mov eax, 0                            |     eax = 0;
    0x080483f2 add eax, 0xf                          |     eax += 0xf;
    0x080483f5 add eax, 0xf                          |     eax += 0xf;
    0x080483f8 shr eax, 4                            |     eax >>= 4;
    0x080483fb shl eax, 4                            |     eax <<= 4;
    0x080483fe sub esp, eax                          |     
    0x08048400 mov dword [esp], 0x8048548            |     
    0x08048407 call 0x804831c                        |     printf ("IOLI Crackme Level 0x02\n");
    0x0804840c mov dword [esp], 0x8048561            |     
    0x08048413 call 0x804831c                        |     printf ("Password: ");
    0x08048418 lea eax, [ebp - 4]                    |     eax = ebp - 4;
    0x0804841b mov dword [esp + 4], eax              |     *((int32_t*) (esp + 4)) = eax;
    0x0804841f mov dword [esp], 0x804856c            |     
    0x08048426 call 0x804830c                        |     scanf (0x804856c);
    0x0804842b mov dword [ebp - 8], 0x5a             |     *((int32_t*) (ebp - 8)) = 0x5a;
    0x08048432 mov dword [ebp - 0xc], 0x1ec          |     *((int32_t*) (ebp - 0xc)) = 0x1ec;
    0x08048439 mov edx, dword [ebp - 0xc]            |     edx = *((int32_t*) (ebp - 0xc));
    0x0804843c lea eax, [ebp - 8]                    |     eax = ebp - 8;
    0x0804843f add dword [eax], edx                  |     *((int32_t*) eax) += edx;
    0x08048441 mov eax, dword [ebp - 8]              |     eax = *((int32_t*) (ebp - 8));
    0x08048444 imul eax, dword [ebp - 8]             |     eax *= *((int32_t*) (ebp - 8));
    0x08048448 mov dword [ebp - 0xc], eax            |     *((int32_t*) (ebp - 0xc)) = eax;
    0x0804844b mov eax, dword [ebp - 4]              |     eax = *((int32_t*) (ebp - 4));
    0x0804844e cmp eax, dword [ebp - 0xc]            |     
                                                     |     if (eax == *((int32_t*) (ebp - 0xc))) {
    0x08048451 jne 0x8048461                         |         
    0x08048453 mov dword [esp], 0x804856f            |         
    0x0804845a call 0x804831c                        |         printf ("Password OK :)\n");
    0x0804845f jmp 0x804846d                         |         
                                                     |     } else {
    0x08048461 mov dword [esp], 0x804857f            |         
    0x08048468 call 0x804831c                        |         printf ("Invalid Password!\n");
                                                     |     }
    0x0804846d mov eax, 0                            |     eax = 0;
    0x08048472 leave                                 |     
    0x08048473 ret                                   |     return eax;
                                                     | }
```