### PR TITLE
Fix redefinition warning

### DIFF
--- a/p/r2dec_ctx.h
+++ b/p/r2dec_ctx.h
@@ -3,10 +3,9 @@
 #define R2DEC_CTX_H
 
 #include <duktape.h>
-#include <r_core.h>
 
 typedef struct r2dec_ctx_t {
-	RCore *core;
+	void *core;
 	void *bed;
 } R2DecCtx;
 


### PR DESCRIPTION
./r2dec_ctx.h:7:25: warning: redefinition of typedef 'RCore' is a C11 feature [-Wtypedef-redefinition]