### PR TITLE
RISCV: auipc: fix wrong offset generated

### DIFF
--- a/libdec/arch/riscv.js
+++ b/libdec/arch/riscv.js
@@ -182,8 +182,8 @@
         instructions: {
             auipc: function(instr) {
                 var dst = instr.parsed.opd[0];
-                var imm32 = parseInt(instr.parsed.opd[1]);
-                var src = instr.location.add(imm32);
+                var imm20 = instr.parsed.opd[1] << 12;
+                var src = instr.location.add(imm20);
                 return Base.assign(dst, '0x' + src.toString(16)) ;
             },
             lui: function(instr) {

--- a/libdec/arch/riscv.js
+++ b/libdec/arch/riscv.js
@@ -182,7 +182,7 @@
         instructions: {
             auipc: function(instr) {
                 var dst = instr.parsed.opd[0];
-                var imm20 = instr.parsed.opd[1] << 12;
+                var imm20 = parseInt(instr.parsed.opd[1]) << 12;
                 var src = instr.location.add(imm20);
                 return Base.assign(dst, '0x' + src.toString(16)) ;
             },


### PR DESCRIPTION
imm is added to upper 20 bits of pc, not to lower 12 bits