### PR TITLE
fix build, fails with ld missing '_atomic_*' during link of libquickjs.

### DIFF
--- a/subprojects/packagefiles/libquickjs/meson.build
+++ b/subprojects/packagefiles/libquickjs/meson.build
@@ -7,6 +7,7 @@ cc = meson.get_compiler('c')
 have_msvc = cc.get_id() == 'msvc'
 
 threads_dep = dependency('threads')
+atomic_dep = cc.find_library('atomic', required: false)
 dl_dep = cc.find_library('dl', required: false)
 m_dep = cc.find_library('m', required: false)
 
@@ -82,7 +83,7 @@ add_project_arguments(
 )
 
 quickjs = static_library('quickjs', sources,
-  dependencies: [threads_dep, dl_dep, m_dep],
+  dependencies: [atomic_dep, threads_dep, dl_dep, m_dep],
   implicit_include_directories: false,
   install: false,
 )


### PR DESCRIPTION
raspberry pi4, debian bookworm.
fails to link on arm-aarch64 with 32bit userspace.

	modified:   subprojects/packagefiles/libquickjs/meson.build