### PR TITLE
Support offset/addr fields in aflj/afij and basic blocks

### DIFF
--- a/js/libdec/core.js
+++ b/js/libdec/core.js
@@ -157,7 +157,11 @@ var _session = function(data, arch) {
     var max_length = 0;
     var max_address = 8;
     Global().xrefs = new XRefs(strings, symbols, classes);
-    data.graph[0].blocks.sort((a, b) => { return a.offset.compare(b.offset); });
+    if (data.graph[0].blocks[0].addr) {
+        data.graph[0].blocks.sort((a, b) => { return a.addr.compare(b.addr); });
+    } else {
+        data.graph[0].blocks.sort((a, b) => { return a.offset.compare(b.offset); });
+    }
     for (var i = 0; i < data.graph[0].blocks.length; i++) {
         var block = data.graph[0].blocks[i];
         // This is hacky but it is required by wasm..

--- a/js/libdec/core/functions.js
+++ b/js/libdec/core/functions.js
@@ -26,9 +26,9 @@ var create_fcn_data = function(x) {
         return null;
     }
     return {
-        offset: x.offset,
+        offset: x.offset?? x.addr,
         name: x.name,
-        calltype: x.calltype,
+        calltype: x.calltype?? x.callconv,
         nargs: x.nargs
     };
 };

--- a/js/libdec/core/functions.js
+++ b/js/libdec/core/functions.js
@@ -26,9 +26,9 @@ var create_fcn_data = function(x) {
         return null;
     }
     return {
-        offset: x.offset?? x.addr,
+        offset: x.addr?? x.offset,
         name: x.name,
-        calltype: x.calltype?? x.callconv,
+        calltype: x.callconv?? x.calltype,
         nargs: x.nargs
     };
 };

--- a/js/libdec/r2util.js
+++ b/js/libdec/r2util.js
@@ -21,6 +21,18 @@ export default (function() {
         return r2_sanitize(arch);
     }
 
+    function aflj() {
+        const functions = r2pipe.json('aflj', []);
+        console.log(functions);
+        if (functions.length > 0 && functions[0].addr) {
+            return functions.map((x) => {
+                    x.offset = x.addr?? x.offset;
+                    return x;
+                });
+        }
+        return functions;
+    }
+
     function r2_sanitize(value, expected) {
         return value.length == 0 ? expected : value;
     }
@@ -262,17 +274,6 @@ export default (function() {
             var isfast = !r2pipe.bool('e r2dec.slow');
             this.arch = r2_arch();
             this.bits = r2pipe.int('e asm.bits', 32);
-            function aflj() {
-                const functions = r2pipe.json('aflj', []);
-                console.log(functions);
-                if (functions.length > 0 && functions[0].addr) {
-                    return functions.map((x) => {
-                            x.offset = x.addr?? x.offset;
-                            return x;
-                        });
-                }
-                return functions;
-            }
             this.xrefs = {
                 symbols: (isfast ? [] : r2pipe.json('isj', [])),
                 strings: (isfast ? [] : r2pipe.json('Csj', [])),

--- a/js/libdec/r2util.js
+++ b/js/libdec/r2util.js
@@ -262,10 +262,21 @@ export default (function() {
             var isfast = !r2pipe.bool('e r2dec.slow');
             this.arch = r2_arch();
             this.bits = r2pipe.int('e asm.bits', 32);
+            function aflj() {
+                const functions = r2pipe.json('aflj', []);
+                console.log(functions);
+                if (functions.length > 0 && functions[0].addr) {
+                    return functions.map((x) => {
+                            x.offset = x.addr?? x.offset;
+                            return x;
+                        });
+                }
+                return functions;
+            }
             this.xrefs = {
                 symbols: (isfast ? [] : r2pipe.json('isj', [])),
                 strings: (isfast ? [] : r2pipe.json('Csj', [])),
-                functions: (isfast ? [] : r2pipe.json('aflj', [])),
+                functions: (isfast ? [] : aflj()),
                 classes: r2pipe.json('icj', []),
                 arguments: offset_long(r2pipe.json('afvj', {
                     "sp": [],


### PR DESCRIPTION
i have introduced some breaking changes in r2 structs and json objects. in this case offset is now named "addr" for function and basic blocks. im not sure if this is the most elegant way to handle that in r2dec, but that patch works with latest r2