### PR TITLE
r2 >= 6.x changed the aflj JSON key from offset to addr

### DIFF
--- a/js/r2dec-plugin.js
+++ b/js/r2dec-plugin.js
@@ -66,9 +66,10 @@ function main(args) {
 					if (x.name.startsWith('sym.imp.') || x.name.startsWith('loc.imp.')) {
 						return;
 					}
-					r2pipe.string('s 0x' + x.offset.toString(16));
-					Shared.context.printLine("", x.offset);
-					Shared.context.printLine(Shared.printer.theme.comment('/* name: ' + x.name + ' @ 0x' + x.offset.toString(16) + ' */'), x.offset);
+					var fcn_addr = x.offset || x.addr;
+					r2pipe.string('s 0x' + fcn_addr.toString(16));
+					Shared.context.printLine("", fcn_addr);
+					Shared.context.printLine(Shared.printer.theme.comment('/* name: ' + x.name + ' @ 0x' + fcn_addr.toString(16) + ' */'), fcn_addr);
 					decompile_offset(architecture, x.name);
 				});
 				r2pipe.string('s 0x' + current.toString(16));


### PR DESCRIPTION
I tested https://github.com/wargio/r2dec-js/pull/388 with my treadmill project, [flash.bin from the control board](https://github.com/brainstorm/treadmill-re/blob/master/control/flash.bin). And it crashed:

```
$ r2 -a stm8 -b 16 -n -m 0x8000 -c '
e asm.cpu=stm8
e anal.hasnext=true
e anal.cc=reg
e emu.str=true
afr
aar
pddf
' -q /home/rvalls/dev/personal/treadmill-re/control/flash.bin > /tmp/opencode/r2dec-output/all_functions.c 2>/dev/null
```

Then looking at the output:

```C
$ cat /tmp/opencode/r2dec-output/all_functions.c
// 
// 
// r2dec has crashed (info: /home/rvalls/dev/personal/treadmill-re/control/flash.bin @ 0x8000).
// Please report the bug at https://github.com/wargio/r2dec-js/issues
// Enable -e r2dec.debug=true to check the javascript backtrace.
// Use the command 'pddi' to generate the needed data for the issue.
```

The pddf command crashed with TypeError: cannot read property 'toString' of undefined at line 69. The fix uses x.offset || x.addr (renamed to fcn_addr) for backward compatibility with both old and new r2 versions.

Chatting with @trufae, he mentioned that there could potentially be similar bugs in the rest of the codebase? I just focused on STM8, just so you know!

